### PR TITLE
removed show button from edit page

### DIFF
--- a/app/views/watches/edit.html.erb
+++ b/app/views/watches/edit.html.erb
@@ -1,4 +1,3 @@
 <h1>Edit <%= @watch.name %></h1>
 <%= render "form" %>
-<p><%= link_to "Show", watches_path %></p>
 <p><%= link_to "Back", watch_path(@watch) %></p>


### PR DESCRIPTION
There was button called "show" in watches/:id/edit page which takes the user to /watches
Since we have back button that will take the user back to the watches/:id  I removed useless Show button.